### PR TITLE
Make ObjectId changes work with AssemblyProcessor*

### DIFF
--- a/sources/core/Stride.Core.Tests/ObjectIdTests.cs
+++ b/sources/core/Stride.Core.Tests/ObjectIdTests.cs
@@ -1,0 +1,17 @@
+using Stride.Core.Storage;
+using Xunit;
+
+namespace Stride.Core.Tests
+{
+    public class ObjectIdTests
+    {
+        [Fact]
+        public void ToString_ThenTryParse_GivesTheSameResult()
+        {
+            var id = ObjectId.New();
+            var str = id.ToString();
+            Assert.True(ObjectId.TryParse(str, out var parsed));
+            Assert.Equal(id, parsed);
+        }
+    }
+}

--- a/sources/core/Stride.Core/Storage/ObjectId.cs
+++ b/sources/core/Stride.Core/Storage/ObjectId.cs
@@ -227,8 +227,8 @@ namespace Stride.Core.Storage
 #if NET6_0_OR_GREATER
             fixed (uint* hashStart = &hash1)
             {
-                return string.Create(HashStringLength, (IntPtr)hashStart, (c, state) => {
-
+                return string.Create(HashStringLength, (IntPtr)hashStart, (c, state) =>
+                {
                     var hashBytes = (byte*)state;
                     for (var i = 0; i < HashStringLength; ++i)
                     {
@@ -239,7 +239,6 @@ namespace Stride.Core.Storage
                         b = (byte)(hashBytes[index0] & 0x0F);
                         c[i] = HexDigits[b];
                     }
-
                 });
             }
 #else


### PR DESCRIPTION
# PR Details

Added the `#if` check to use the fast version when available or the other one in netstandard. Verified the assembly processor is building and running this code correctly. Also removed allocation from `TryParse`.